### PR TITLE
[HMR] Fixed ignoring paths with dots in directory name

### DIFF
--- a/server/hot-reloader.js
+++ b/server/hot-reloader.js
@@ -169,7 +169,7 @@ export default class HotReloader {
     })
 
     const ignored = [
-      /(^|[/\\])\../, // .dotfiles
+      /(?:^|[\\\/])(\.(?!\.)[^\\\/]+)$/, // .dotfiles
       /node_modules/
     ]
     const windowsSettings = isWindowsBash() ? {


### PR DESCRIPTION
Using regex from [dotfile-regex](https://github.com/regexhq/dotfile-regex)

## Result

Fixed for `.` directory in path not triggering HMR. 

## Todo

- [ ] Check if this resolves other symbols in path problems (eg. `~/projects/api (1)/`)